### PR TITLE
Relax requests requirement using ~=2.26

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(
     packages=find_packages(exclude=["test", "test.*", "examples", "examples.*"]),
     python_requires=">=3.8.*",
     include_package_data=True,
-    install_requires=["requests==2.26.0"],
+    install_requires=["requests~=2.26.0"],
 )


### PR DESCRIPTION
Hello!

In order to not have such strict requirements for `requests` I changed the requirement to use the compatible version operator `~=2.26`, this is basically equivalent to `>=2.26,<3`

The current version only allows heron-data to work with version `2.26.0` of requests (not even a patch version change like `2.26.1` would match) which makes it unpractical to use in other environments where requests is at a different version.

This would close #13 